### PR TITLE
Render children props

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # react-fuzzy-filter
 
-Fuzzy filter a list of data based on the search value typed in the input field. Each matching list item is rendered via a custom render function.
+Fuzzy filter a list of data based on the search value typed in the input field. Each matching list item is made available as an argument to the FilterResults component's child function.
 
 ReactFuzzyFilter is powered by [`fuse.js`](https://github.com/krisk/Fuse).
 
@@ -26,10 +26,6 @@ import fuzzyFilterFactory from 'react-fuzzy-filter';
 const {InputFilter, FilterResults} = fuzzyFilterFactory();
 
 class MyComponent extends Component {
-  renderItem(item, index) {
-    return <div key={item.meta}>{item.name}</div>;
-  }
-
   render() {
     const items = [
       { name: 'first', meta: 'first|123', tag: 'a' },
@@ -45,9 +41,15 @@ class MyComponent extends Component {
         <div>Any amount of content between</div>
         <FilterResults
           items={items}
-          renderItem={this.renderItem}
-          fuseConfig={fuseConfig}
-        />
+          fuseConfig={fuseConfig}>
+          {filteredItems => {
+            return(
+              <div>
+                {filteredItems.forEach(item => <div>{item.name}</div>)}
+              </div>
+            )
+          }}
+        </FilterResults>
       </div>
     );
   }
@@ -93,10 +95,6 @@ Collection of fuzzy filtered items (filtered by the `InputFilter`'s value), each
 
 `fuseConfig` is an object that specifies configuration for [`fuse.js`](https://github.com/krisk/Fuse), the library that is doing the fuzzy searching. The only required key in this object is `keys`, which is an array that specifies the key(s), in the objects to use for comparison. Check out all of the configuration [options](https://github.com/krisk/Fuse#options).
 
-### renderItem
-
-`renderItem` is a required function that defines how each match is rendered. It receives the item and the index as arguments and should return a React element.
-
 ### items
 
 `items` is an array of the objects to be rendered. It defaults to an empty array.
@@ -104,22 +102,6 @@ Collection of fuzzy filtered items (filtered by the `InputFilter`'s value), each
 ### defaultAllItems
 
 `defaultAllItems` is a boolean that determines whether all items should be shown if the search value is empty. It defaults to true (meaning all items are shown by default).
-
-#### classPrefix
-
-`classPrefix` is a string that is used to prefix the class names in the component. It defaults to `react-fuzzy-filter`. (`react-fuzzy-filter__results-container`)
-
-### wrapper
-
-`wrapper` is an optional component that will wrap the results if defined. This will be used as the wrapper around the items INSTEAD of `react-fuzzy-filter__results-container`.
-
-### wrapperProps
-
-`wrapperProps` is an optional object containing additional props to be passed to the `wrapper`.
-
-### renderContainer
-
-`renderContainer` is an alternative to using `wrapper` and `wrapperProps`. It is a function that is used as the render function for `FilterResults`. It receives two arguments, an array of React elements (the items after they have already been transformed by `renderItem`, as well as an array of the raw items. It should return a React element.
 
 ### prefilters
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # react-fuzzy-filter
 
-Fuzzy filter a list of data based on the search value typed in the input field. Each matching list item is made available as an argument to the FilterResults component's child function.
+Fuzzy filter a list of data based on the search value typed in the input field. The list of matching items is made available as an argument to the FilterResults component's child function.
 
 ReactFuzzyFilter is powered by [`fuse.js`](https://github.com/krisk/Fuse).
 

--- a/src/FilterResults.js
+++ b/src/FilterResults.js
@@ -74,9 +74,7 @@ export default function filterResultsFactory(store) {
 
     render() {
       const filteredItems = this.filterItems();
-      return(
-        this.props.children(filteredItems)
-      );
+      return this.props.children(filteredItems);
     }
   }
 

--- a/src/FilterResults.js
+++ b/src/FilterResults.js
@@ -6,13 +6,9 @@ export default function filterResultsFactory(store) {
     static displayName = 'FilterResults';
 
     static propTypes = {
-      renderItem: PropTypes.func.isRequired,
+      children: PropTypes.func.isRequired,
       items: PropTypes.array.isRequired,
       defaultAllItems: PropTypes.bool,
-      classPrefix: PropTypes.string,
-      wrapper: PropTypes.any,
-      wrapperProps: PropTypes.object,
-      renderContainer: PropTypes.func,
       fuseConfig: PropTypes.shape({
         keys: PropTypes.array.isRequired,
         id: PropTypes.string,
@@ -39,8 +35,6 @@ export default function filterResultsFactory(store) {
 
     static defaultProps = {
       defaultAllItems: true,
-      classPrefix: 'react-fuzzy-filter',
-      wrapperProps: {},
       prefilters: []
     };
 
@@ -78,23 +72,10 @@ export default function filterResultsFactory(store) {
       }
     }
 
-    renderItems(items) {
-      return items.map((item, i) => this.props.renderItem(item, i));
-    }
-
     render() {
-      const rawItems = this.filterItems();
-      const items = this.renderItems(rawItems);
-      if (typeof this.props.renderContainer === 'function') {
-        return this.props.renderContainer(items, rawItems);
-      }
-      if (this.props.wrapper) {
-        return React.createElement(this.props.wrapper, this.props.wrapperProps, items);
-      }
-      return (
-        <span className={`${this.props.classPrefix}__results-container`}>
-          {items}
-        </span>
+      const filteredItems = this.filterItems();
+      return(
+        this.props.children(filteredItems)
       );
     }
   }

--- a/src/FilterResults.js
+++ b/src/FilterResults.js
@@ -1,4 +1,4 @@
-import React, {PropTypes, Component} from 'react';
+import {PropTypes, Component} from 'react';
 import Fuse from 'fuse.js';
 
 export default function filterResultsFactory(store) {

--- a/test/FilterResults_test.js
+++ b/test/FilterResults_test.js
@@ -1,5 +1,5 @@
 import expect from 'expect';
-import {shallow, mount} from 'enzyme';
+import {shallow} from 'enzyme';
 import React, { } from 'react';
 import {Subject} from 'rxjs/Subject';
 import filterResultsFactory from '../src/FilterResults';
@@ -27,13 +27,13 @@ describe('FilterResults', () => {
 
   describe('#render', () => {
     it('passes filtered items to child function', () => {
-      const component = shallow(<FilterResults items={items} fuseConfig={defaultFuseConfig}>{filteredResultsSpy}</FilterResults>);
+      shallow(<FilterResults items={items} fuseConfig={defaultFuseConfig}>{filteredResultsSpy}</FilterResults>);
       expect(filteredResultsSpy.calls.length).toEqual(1);
       expect(filteredResultsSpy.calls[0].arguments[0]).toEqual(items);
     });
 
     it('renders no items with empty search if defaultAllItems is false', () => {
-      const component = shallow(
+      shallow(
         <FilterResults
           items={items}
           fuseConfig={defaultFuseConfig}

--- a/test/FilterResults_test.js
+++ b/test/FilterResults_test.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
 import {shallow} from 'enzyme';
-import React, { } from 'react';
+import React from 'react';
 import {Subject} from 'rxjs/Subject';
 import filterResultsFactory from '../src/FilterResults';
 


### PR DESCRIPTION
This PR cleans up the React Fuzzy Filter API by giving developers more control over how they render the resultant filtered results.

Before this PR, users of the API had to pass in the container and rendering structure, which React Fuzzy Filter rendered for them.

The new code lets React Fuzzy Filter act as a thin wrapper that simply takes in items and then returns the filtered result, which can be used however the developer wants as an argument to a child function.

These changes do restrict users of the API to passing a function into the `FilterResults` component, which would be a breaking change from previous versions.