### PR TITLE
Improve data consistency despite component render order

### DIFF
--- a/src/InputFilter.js
+++ b/src/InputFilter.js
@@ -8,13 +8,7 @@ export default function inputFilterFactory(store) {
     if (typeof overrideValue === "string") {
       value = overrideValue;
     }
-    if (async) {
-      // ensure first update happens async so that ResultsFilter
-      // gets initialSearch, even if it is mounted after InputFilter
-      setTimeout(() => store(value));
-    } else {
-      store(value);
-    }
+    store(value);
   }
 
   class InputFilter extends Component {

--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,28 @@ import valoo from "valoo";
 import inputFilterFactory from "./InputFilter";
 import filterResultsFactory from "./FilterResults";
 
-export default function fuzzyFilterFactory() {
+// emulates BehaviorSubject from rxjs
+// (stores current state) and replays it on subscribe
+function behaviorStore() {
   const store = valoo();
+  let currentState;
+  // save currentState before emitting
+  function emit(val) {
+    currentState = val;
+    store(val);
+  }
+
+  // emit currentState on subscribe
+  // then use default valoo behavior
+  emit.on = function(cb) {
+    cb(currentState);
+    store.on(cb);
+  };
+  return emit;
+}
+
+export default function fuzzyFilterFactory() {
+  const store = behaviorStore();
   return {
     InputFilter: inputFilterFactory(store),
     FilterResults: filterResultsFactory(store),


### PR DESCRIPTION
This essentially emulates the behavior similar rxjs [BehaviorSubject](http://reactivex.io/rxjs/manual/overview.html#behaviorsubject) in valoo store. In the past this library used the `BehaviorSubject` from rxjs, but moved to valoo to reduce the library size (and since no other rx features were being used).

- keep track of current value so that if FilterResults gets mounted after InputFilter, it will still display the correct data
- gets rid of imperfect `setTimeout` hack, which was the way this was being done before
- helps prepare for async react